### PR TITLE
Allow entries to have multiple links

### DIFF
--- a/app/controllers/admin/entries_controller.rb
+++ b/app/controllers/admin/entries_controller.rb
@@ -5,6 +5,7 @@ class Admin::EntriesController < Admin::AdminController
 
   def new
     @entry = Entry.new
+    @entry.links.build
   end
 
   def create
@@ -46,6 +47,12 @@ class Admin::EntriesController < Admin::AdminController
   private
 
   def entry_params
-    params.require(:entry).permit(:name, :cover, :description, tag_ids: [])
+    params.require(:entry).permit(
+      :name,
+      :cover,
+      :description,
+      tag_ids: [],
+      links_attributes: [:id, :address, :type, :_destroy]
+    )
   end
 end

--- a/app/helpers/links_helper.rb
+++ b/app/helpers/links_helper.rb
@@ -1,0 +1,16 @@
+module LinksHelper
+  LINK_EXPRESSIONS = [
+    /(?<name>itch\.io)/,
+    /^(?:https?:\/\/)?(?:www\.)?(?<name>[\w\d.]+)\/?/
+  ]
+
+  def link_name(link)
+    match = LINK_EXPRESSIONS.detect do |expression|
+      link.address =~ expression
+    end
+
+    return link.address unless match
+
+    match.match(link.address)["name"]
+  end
+end

--- a/app/javascript/controllers/nested_form_controller.js
+++ b/app/javascript/controllers/nested_form_controller.js
@@ -1,0 +1,41 @@
+import { Controller } from "stimulus"
+
+export default class extends Controller {
+  static targets = ["links", "template", "form"]
+
+  connect() {
+    this.wrapperClass = this.data.get("wrapperClass") || "nested-fields"
+  }
+
+  addAssociation(event) {
+    event.preventDefault()
+
+    const content = this.templateTarget.innerHTML.replace(
+      /NEW_RECORD/g,
+      new Date().getTime()
+    )
+    this.formTarget.insertAdjacentHTML("beforeend", content)
+  }
+
+  removeAssociation(event) {
+    event.preventDefault()
+
+    const wrapper = event.target.closest("." + this.wrapperClass)
+
+    if (wrapper.dataset.newRecord == "true") {
+      this.removeNewAssociation(wrapper)
+    } else {
+      this.removeExistingAssociation(wrapper)
+    }
+  }
+
+  removeNewAssociation(wrapper) {
+    wrapper.remove()
+  }
+
+  removeExistingAssociation(wrapper) {
+    console.log("remove existing association")
+    wrapper.querySelector("input[name*='_destroy']").value = "true"
+    wrapper.style.display = "none"
+  }
+}

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -10,6 +10,7 @@ class Entry < ApplicationRecord
   HTML
 
   has_and_belongs_to_many :tags
+  has_many :links, dependent: :destroy
 
   validates :name, presence: true
   validates :description, presence: true
@@ -18,10 +19,12 @@ class Entry < ApplicationRecord
   has_one_attached :cover
   has_rich_text :description
 
+  accepts_nested_attributes_for :links, allow_destroy: true, reject_if: :all_blank
+
   scope :containing, ->(query) { content_containing(query).or(name_containing(query)) }
   scope :content_containing, ->(query) { joins(:rich_text_description).merge(ActionText::RichText.with_body_containing(query)) }
   scope :name_containing, ->(query) { where("entries.name ILIKE ?", "%#{query}%") }
-  scope :with_includes, -> { includes(:tags, :cover_blob, rich_text_description: :embeds_attachments, cover_attachment: :blob) }
+  scope :with_includes, -> { includes(:tags, :cover_blob, :links, rich_text_description: :embeds_attachments, cover_attachment: :blob) }
 
   private
 

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -1,0 +1,5 @@
+class Link < ApplicationRecord
+  belongs_to :entry
+
+  validates :address, presence: true
+end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -4,5 +4,5 @@ class Tag < ApplicationRecord
   validates :name, presence: true
 
   scope :containing, ->(query) { where("tags.name ILIKE ?", "%#{query}%") }
-  scope :with_includes, -> { includes(entries: [:tags, :rich_text_description, cover_attachment: :blob]) }
+  scope :with_includes, -> { includes(entries: [:links, :tags, :rich_text_description, cover_attachment: :blob]) }
 end

--- a/app/views/admin/entries/_entry.html.erb
+++ b/app/views/admin/entries/_entry.html.erb
@@ -33,6 +33,14 @@
       <div class="plex-mono">
         <%= entry.description %>
       </div>
+
+      <% if entry.links.any? %>
+        <ul>
+          <% entry.links.each do |link| %>
+            <%= content_tag :li, link_to(link.address, link.address) %>
+          <% end %>
+        </ul>
+      <% end %>
     </div>
   </div>
 </div>

--- a/app/views/admin/entries/_form.html.erb
+++ b/app/views/admin/entries/_form.html.erb
@@ -27,25 +27,14 @@
     <h2>Links</h2>
     <template data-nested-form-target="template">
       <%= form.fields_for :links, Link.new, child_index: "NEW_RECORD" do |link_form| %>
-        <%= content_tag :div, class: "nested-fields", data: { new_record: link_form.object.new_record? } do %>
-          <%= link_form.label :address %>
-          <%= link_form.text_field :address %>
-          <a data-action="click->nested-form#removeAssociation">Remove</a>
-        <%= link_form.hidden_field :_destroy %>
-        <% end %>
+        <%= render partial: "link_form", locals: { form: link_form } %>
       <% end %>
     </template>
 
     <div data-nested-form-target="form" class="stack | stack-s3">
       <%= form.fields_for :links do |link_form| %>
         <%= content_tag :div, class: "nested-fields", data: { new_record: link_form.object.new_record? } do %>
-          <%= link_form.label :address %>
-          <% link_form.object.errors.full_messages_for(:address).each do |error| %>
-            <%= content_tag :span, error %>
-          <% end %>
-          <%= link_form.text_field :address %>
-          <a data-action="click->nested-form#removeAssociation">Remove</a>
-          <%= link_form.hidden_field :_destroy %>
+          <%= render partial: "link_form", locals: { form: link_form } %>
         <% end %>
       <% end %>
     </div>

--- a/app/views/admin/entries/_form.html.erb
+++ b/app/views/admin/entries/_form.html.erb
@@ -23,13 +23,49 @@
     <%= form.rich_text_area :description, value: @entry.description.presence || Entry::DEFAULT_DESCRIPTION %>
   </div>
 
-  <div>
-    <%= form.collection_check_boxes :tag_ids, Tag.all, :id, :name do |b| %>
-      <%= b.label do %>
-        <%= b.check_box %>
-        <%= b.text %>
+  <div class="stack | stack-s3" data-controller="nested-form">
+    <h2>Links</h2>
+    <template data-nested-form-target="template">
+      <%= form.fields_for :links, Link.new, child_index: "NEW_RECORD" do |link_form| %>
+        <%= content_tag :div, class: "nested-fields", data: { new_record: link_form.object.new_record? } do %>
+          <%= link_form.label :address %>
+          <%= link_form.text_field :address %>
+          <a data-action="click->nested-form#removeAssociation">Remove</a>
+        <%= link_form.hidden_field :_destroy %>
+        <% end %>
       <% end %>
-    <% end %>
+    </template>
+
+    <div data-nested-form-target="form" class="stack | stack-s3">
+      <%= form.fields_for :links do |link_form| %>
+        <%= content_tag :div, class: "nested-fields", data: { new_record: link_form.object.new_record? } do %>
+          <%= link_form.label :address %>
+          <% link_form.object.errors.full_messages_for(:address).each do |error| %>
+            <%= content_tag :span, error %>
+          <% end %>
+          <%= link_form.text_field :address %>
+          <a data-action="click->nested-form#removeAssociation">Remove</a>
+          <%= link_form.hidden_field :_destroy %>
+        <% end %>
+      <% end %>
+    </div>
+
+    <div>
+      <button data-action="click->nested-form#addAssociation">Add Link</button>
+    </div>
+  </div>
+
+  <div class="stack | stack-s3">
+    <h2>Tags</h2>
+
+    <div>
+      <%= form.collection_check_boxes :tag_ids, Tag.all, :id, :name do |b| %>
+        <%= b.label do %>
+          <%= b.check_box %>
+          <%= b.text %>
+        <% end %>
+      <% end %>
+    </div>
   </div>
 
   <%= form.submit %>

--- a/app/views/admin/entries/_link_form.html.erb
+++ b/app/views/admin/entries/_link_form.html.erb
@@ -1,0 +1,9 @@
+<%= content_tag :div, class: "nested-fields", data: { new_record: form.object.new_record? } do %>
+  <%= form.label :address %>
+  <% form.object.errors.full_messages_for(:address).each do |error| %>
+    <%= content_tag :span, error %>
+  <% end %>
+  <%= form.text_field :address %>
+  <a data-action="click->nested-form#removeAssociation">Remove</a>
+  <%= form.hidden_field :_destroy %>
+<% end %>

--- a/app/views/entries/_entry.html.erb
+++ b/app/views/entries/_entry.html.erb
@@ -22,6 +22,14 @@
       <div class="plex-mono">
         <%= entry.description %>
       </div>
+
+      <% if entry.links.any? %>
+        <ul>
+          <% entry.links.each do |link| %>
+            <%= content_tag :li, link_to(link.address, link.address) %>
+          <% end %>
+        </ul>
+      <% end %>
     </div>
   </div>
 </div>

--- a/app/views/entries/_entry.html.erb
+++ b/app/views/entries/_entry.html.erb
@@ -11,25 +11,33 @@
     <div class="stack">
       <h1 class="unifraktur"><%= link_to entry.name, entry %></h1>
 
-      <div class="cluster">
-        <div class="plex-mono">
-          <% entry.tags.each do |tag| %>
-            <%= link_to tag.name, tag %>
-          <% end %>
+      <% if entry.links.any? %>
+        <div class="cluster">
+          <div class="plex-mono">
+            <strong><%= Link.model_name.human.pluralize %>:</strong>
+
+            <% entry.links.each do |link| %>
+              <%= link_to link_name(link), link.address %>
+            <% end %>
+          </div>
         </div>
-      </div>
+      <% end %>
+
+      <% if entry.tags.any? %>
+        <div class="cluster">
+          <div class="plex-mono">
+            <strong><%= Tag.model_name.human.pluralize %>:</strong>
+
+            <% entry.tags.each do |tag| %>
+              <%= link_to tag.name, tag %>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
 
       <div class="plex-mono">
         <%= entry.description %>
       </div>
-
-      <% if entry.links.any? %>
-        <ul>
-          <% entry.links.each do |link| %>
-            <%= content_tag :li, link_to(link.address, link.address) %>
-          <% end %>
-        </ul>
-      <% end %>
     </div>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -42,6 +42,8 @@ en:
         delete_button: Delete Entry
         delete_button_confirmation: Are you sure you want to delete this entry?
         edit_link: Edit Entry
+      _form:
+        add_link: Add Link
     tags:
       index:
         title: All Tags

--- a/db/migrate/20210418151932_create_links.rb
+++ b/db/migrate/20210418151932_create_links.rb
@@ -1,0 +1,10 @@
+class CreateLinks < ActiveRecord::Migration[6.1]
+  def change
+    create_table :links, id: :uuid do |t|
+      t.belongs_to :entry, null: false, foreign_key: true, type: :uuid
+      t.string :address
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_17_113042) do
+ActiveRecord::Schema.define(version: 2021_04_18_151932) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -68,6 +68,14 @@ ActiveRecord::Schema.define(version: 2021_04_17_113042) do
     t.index ["tag_id", "entry_id"], name: "index_entries_tags_on_tag_id_and_entry_id"
   end
 
+  create_table "links", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "entry_id", null: false
+    t.string "address"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["entry_id"], name: "index_links_on_entry_id"
+  end
+
   create_table "tags", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", precision: 6, null: false
@@ -87,4 +95,5 @@ ActiveRecord::Schema.define(version: 2021_04_17_113042) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "links", "entries"
 end

--- a/test/controllers/admin/entries_controller_test.rb
+++ b/test/controllers/admin/entries_controller_test.rb
@@ -57,13 +57,16 @@ class Admin::EntriesControllerTest < ActionDispatch::IntegrationTest
         name: "The Black Salt",
         description: "A description",
         cover: fixture_file_upload("eatpreykill.png", "image/png"),
-        tag_ids: [tags(:rules).id]
+        tag_ids: [tags(:rules).id],
+        links_attributes: [{address: "https://liberludorum.com/ex-libris-mork-borg-optional-rules/"}]
       }}
 
       assert_changes -> { Entry.count } do
         assert_changes -> { tags(:rules).entries.count } do
           assert_changes -> { ActiveStorage::Attachment.count } do
-            post admin_entries_path, params: valid_params
+            assert_changes -> { Link.count } do
+              post admin_entries_path, params: valid_params
+            end
           end
         end
       end
@@ -135,6 +138,18 @@ class Admin::EntriesControllerTest < ActionDispatch::IntegrationTest
       end
 
       assert_redirected_to admin_entry_path(entry)
+    end
+
+    should "delete specified links" do
+      sign_in
+
+      entry = entries(:eat_prey_kill)
+      link = links(:eat_prey_kill_itch)
+      valid_params = {entry: {links_attributes: [{id: link.id, _destroy: "true"}]}}
+
+      assert_changes -> { entry.links.count } do
+        patch admin_entry_path(entry), params: valid_params
+      end
     end
   end
 

--- a/test/fixtures/links.yml
+++ b/test/fixtures/links.yml
@@ -1,3 +1,11 @@
 eat_prey_kill_itch:
   entry: eat_prey_kill
   address: https://makedatanotlore.itch.io/eat-prey-kill
+
+eat_prey_kill_mork_borg:
+  entry: eat_prey_kill
+  address: https://morkborg.com/content/
+
+unheroic_feats_mork_borg:
+  entry: unheroic_feats
+  address: https://morkborg.com/content/

--- a/test/fixtures/links.yml
+++ b/test/fixtures/links.yml
@@ -1,0 +1,3 @@
+eat_prey_kill_itch:
+  entry: eat_prey_kill
+  address: https://makedatanotlore.itch.io/eat-prey-kill

--- a/test/helpers/links_helper_test.rb
+++ b/test/helpers/links_helper_test.rb
@@ -1,0 +1,15 @@
+require "test_helper"
+
+class LinksHelperTest < ActionView::TestCase
+  test "should shorten itch links" do
+    link = links(:eat_prey_kill_itch)
+
+    assert_equal "itch.io", link_name(link)
+  end
+
+  test "should return domain for other links" do
+    link = Link.new(address: "https://morkborg.com/content/")
+
+    assert_equal "morkborg.com", link_name(link)
+  end
+end

--- a/test/models/entry_test.rb
+++ b/test/models/entry_test.rb
@@ -2,7 +2,8 @@ require "test_helper"
 
 class EntryTest < ActiveSupport::TestCase
   context "associations" do
-    should have_and_belong_to_many :tags
+    should have_and_belong_to_many(:tags)
+    should have_many(:links).dependent(:destroy)
   end
 
   context "validations" do
@@ -15,6 +16,8 @@ class EntryTest < ActiveSupport::TestCase
     should have_one_attached(:cover)
     should have_rich_text(:description)
   end
+
+  should accept_nested_attributes_for(:links).allow_destroy(true)
 
   context ".containing" do
     should "match on name and description" do

--- a/test/models/link_test.rb
+++ b/test/models/link_test.rb
@@ -1,0 +1,11 @@
+require "test_helper"
+
+class LinkTest < ActiveSupport::TestCase
+  context "associations" do
+    should belong_to :entry
+  end
+
+  context "validations" do
+    should validate_presence_of(:address)
+  end
+end

--- a/test/system/admin/entries_test.rb
+++ b/test/system/admin/entries_test.rb
@@ -61,9 +61,12 @@ class Admin::EntriesTest < ApplicationSystemTestCase
 
     visit edit_admin_entry_path(entry)
     fill_in Entry.human_attribute_name(:name), with: "Eat, Prey, Kill!!!"
+    click_on I18n.t("admin.entries._form.add_link")
+    fill_in Link.human_attribute_name(:address), with: "https://makedatanotlore.itch.io/eat-prey-kill"
     click_on I18n.t("helpers.submit.entry.update")
 
     assert_text "Eat, Prey, Kill!!!"
+    assert_text "itch.io"
   end
 
   test "validate attempts to edit" do

--- a/test/system/admin/entries_test.rb
+++ b/test/system/admin/entries_test.rb
@@ -62,7 +62,7 @@ class Admin::EntriesTest < ApplicationSystemTestCase
     visit edit_admin_entry_path(entry)
     fill_in Entry.human_attribute_name(:name), with: "Eat, Prey, Kill!!!"
     click_on I18n.t("admin.entries._form.add_link")
-    fill_in Link.human_attribute_name(:address), with: "https://makedatanotlore.itch.io/eat-prey-kill"
+    fill_in Link.human_attribute_name(:address), currently_with: "", with: "https://makedatanotlore.itch.io/eat-prey-kill"
     click_on I18n.t("helpers.submit.entry.update")
 
     assert_text "Eat, Prey, Kill!!!"


### PR DESCRIPTION
Allow entries to have multiple links.

Links section added to entries form with add/remove options to manage multiple links
<img width="1438" alt="Screenshot 2021-04-22 at 07 39 56" src="https://user-images.githubusercontent.com/1191840/115667604-f1ccde80-a33d-11eb-9abc-a98596828866.png">
Presents links with shortened names where possible. Currently just taking full host (subdomain and domain) except for itch.io where it will ignore the subdomain.
<img width="1438" alt="Screenshot 2021-04-22 at 07 41 20" src="https://user-images.githubusercontent.com/1191840/115667787-2476d700-a33e-11eb-8a98-3b066e67564c.png">
Closes #18 